### PR TITLE
Rebrand UI for privacy focus and improve history access

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -14,9 +14,9 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Nomadz Compass",
+  title: "Nomadz Privacy Hub",
   description:
-    "Chat with an AI travel copilot to craft remote work adventures and curated itineraries.",
+    "Query sensitive data with a privacy-first agentic system that enforces policies, sanitizes answers, and preserves audit trails.",
 };
 
 export default function RootLayout({

--- a/frontend/app/sign-in/page.tsx
+++ b/frontend/app/sign-in/page.tsx
@@ -62,35 +62,35 @@ export default function SignInPage() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-950 via-indigo-950 to-purple-900 text-slate-100">
       <div className="flex min-h-screen flex-col items-center justify-center px-6 py-16">
-        <Link
-          href="/"
-          className="mb-10 inline-flex items-center gap-3 text-sm font-medium text-white/70 transition hover:text-white"
-        >
-          <svg
-            aria-hidden="true"
-            className="h-4 w-4"
-            viewBox="0 0 20 20"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
+          <Link
+            href="/"
+            className="mb-10 inline-flex items-center gap-3 text-sm font-medium text-white/70 transition hover:text-white"
           >
-            <path
-              d="m12.5 5-5 5 5 5"
-              stroke="currentColor"
-              strokeWidth="1.6"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-          Back to chats
-        </Link>
+            <svg
+              aria-hidden="true"
+              className="h-4 w-4"
+              viewBox="0 0 20 20"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m12.5 5-5 5 5 5"
+                stroke="currentColor"
+                strokeWidth="1.6"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+            Back to workspace
+          </Link>
 
-        <div className="w-full max-w-md rounded-3xl border border-white/10 bg-black/60 p-10 shadow-2xl backdrop-blur-xl">
-          <div className="mb-8 text-center">
-            <h1 className="text-2xl font-semibold">Sign in to Nomadz</h1>
-            <p className="mt-3 text-sm text-white/70">
-              Access your saved itineraries and pick up conversations without missing a beat.
-            </p>
-          </div>
+          <div className="w-full max-w-md rounded-3xl border border-white/10 bg-black/60 p-10 shadow-2xl backdrop-blur-xl">
+            <div className="mb-8 text-center">
+              <h1 className="text-2xl font-semibold">Sign in to Nomadz Privacy Hub</h1>
+              <p className="mt-3 text-sm text-white/70">
+                Access your privacy-audited workspace and continue secure analyses without interruption.
+              </p>
+            </div>
 
           <form onSubmit={handleSubmit} className="space-y-5" noValidate>
             <div className="space-y-2">
@@ -147,9 +147,9 @@ export default function SignInPage() {
           </form>
 
           <p className="mt-8 text-center text-sm text-white/70">
-            New to Nomadz?{" "}
+            New to Nomadz Privacy Hub?{" "}
             <Link href="/sign-up" className="font-semibold text-indigo-200 transition hover:text-indigo-100">
-              Create an account
+              Create your secure account
             </Link>
           </p>
         </div>

--- a/frontend/app/sign-up/page.tsx
+++ b/frontend/app/sign-up/page.tsx
@@ -82,35 +82,35 @@ export default function SignUpPage() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-950 via-indigo-950 to-purple-900 text-slate-100">
       <div className="flex min-h-screen flex-col items-center justify-center px-6 py-16">
-        <Link
-          href="/"
-          className="mb-10 inline-flex items-center gap-3 text-sm font-medium text-white/70 transition hover:text-white"
-        >
-          <svg
-            aria-hidden="true"
-            className="h-4 w-4"
-            viewBox="0 0 20 20"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
+          <Link
+            href="/"
+            className="mb-10 inline-flex items-center gap-3 text-sm font-medium text-white/70 transition hover:text-white"
           >
-            <path
-              d="m12.5 5-5 5 5 5"
-              stroke="currentColor"
-              strokeWidth="1.6"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-          Back to chats
-        </Link>
+            <svg
+              aria-hidden="true"
+              className="h-4 w-4"
+              viewBox="0 0 20 20"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m12.5 5-5 5 5 5"
+                stroke="currentColor"
+                strokeWidth="1.6"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+            Back to workspace
+          </Link>
 
-        <div className="w-full max-w-md rounded-3xl border border-white/10 bg-black/60 p-10 shadow-2xl backdrop-blur-xl">
-          <div className="mb-8 text-center">
-            <h1 className="text-2xl font-semibold">Create your Nomadz account</h1>
-            <p className="mt-3 text-sm text-white/70">
-              Sign up to sync travel chats, itineraries, and insights across every device.
-            </p>
-          </div>
+          <div className="w-full max-w-md rounded-3xl border border-white/10 bg-black/60 p-10 shadow-2xl backdrop-blur-xl">
+            <div className="mb-8 text-center">
+              <h1 className="text-2xl font-semibold">Create your Nomadz Privacy Hub account</h1>
+              <p className="mt-3 text-sm text-white/70">
+                Set up secure access to privacy-governed conversations, policies, and audit trails across every device.
+              </p>
+            </div>
 
           <form onSubmit={handleSubmit} className="space-y-5" noValidate>
             <div className="space-y-2">
@@ -191,13 +191,13 @@ export default function SignUpPage() {
               </p>
             ) : null}
 
-            <button
-              type="submit"
-              disabled={isSubmitting}
-              className="w-full rounded-2xl bg-gradient-to-r from-indigo-500 via-purple-500 to-sky-500 px-4 py-3 text-sm font-semibold text-white shadow-lg transition hover:from-indigo-400 hover:via-purple-400 hover:to-sky-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {isSubmitting ? "Creating account..." : "Create account"}
-            </button>
+              <button
+                type="submit"
+                disabled={isSubmitting}
+                className="w-full rounded-2xl bg-gradient-to-r from-indigo-500 via-purple-500 to-sky-500 px-4 py-3 text-sm font-semibold text-white shadow-lg transition hover:from-indigo-400 hover:via-purple-400 hover:to-sky-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isSubmitting ? "Creating account..." : "Create secure account"}
+              </button>
           </form>
 
           <p className="mt-8 text-center text-sm text-white/70">


### PR DESCRIPTION
## Summary
- refresh the main chat experience with privacy-first messaging, simplified assistant privacy status, and a mobile chat-history drawer
- redirect unauthenticated sends to the sign-in flow while keeping the composer usable, and polish metadata plus placeholders to match the privacy context
- clarify authentication screens with privacy-oriented copy and a clearer “create account” call to action

## Testing
- npm run lint *(fails: missing @eslint/eslintrc because registry access is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9f80b4d8832bb140596eb2e737e8